### PR TITLE
Fixes response and data block for CMD17 and CMD18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>", "Rust Embedded Community Developers"]
+authors = [
+    "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
+    "Rust Embedded Community Developers",
+]
 categories = ["embedded", "no-std"]
 description = "A basic SD/MMC driver for Embedded Rust."
 edition = "2021"
@@ -15,20 +18,20 @@ rust-version = "1.76"
 
 [dependencies]
 bisync = "0.3.0"
-byteorder = {version = "1", default-features = false}
-defmt = {version = "0.3", optional = true}
+byteorder = { version = "1", default-features = false }
+defmt = { version = "0.3", optional = true }
 embassy-futures = "0.1.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-io = "0.6.1"
 embedded-io-async = "0.6.1"
 heapless = "^0.8"
-log = {version = "0.4", default-features = false, optional = true}
+log = { version = "0.4", default-features = false, optional = true }
 
 [dev-dependencies]
 chrono = "0.4"
-embedded-hal-bus = "0.2.0"
-env_logger = "0.10.0"
+embedded-hal-bus = "0.3.0"
+env_logger = "0.11.0"
 flate2 = "1.0"
 hex-literal = "0.4.1"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ designed for readability and simplicity over performance.
 You will need something that implements the `BlockDevice` trait, which can read and write the 512-byte blocks (or sectors) from your card. If you were to implement this over USB Mass Storage, there's no reason this crate couldn't work with a USB Thumb Drive, but we only supply a `BlockDevice` suitable for reading SD and SDHC cards over SPI.
 
 ```rust
-use embedded_sdmmc::{SdCard, VolumeManager, Mode, VolumeIdx};
+use embedded_sdmmc::{SdCard, VolumeManager, Mode, VolumeIdx, power_on};
+// Send initilization sequence
+power_on(spi_bus, cs)?;
 // Build an SD Card interface out of an SPI device, a chip-select pin and the delay object
 let sdcard = SdCard::new(sdmmc_spi, delay);
 // Get the card size (this also triggers card initialisation because it's not been done yet)

--- a/examples/readme_test.rs
+++ b/examples/readme_test.rs
@@ -7,7 +7,7 @@
 
 use core::cell::RefCell;
 
-use embedded_sdmmc::blocking::{Error, SdCardError, TimeSource, Timestamp};
+use embedded_sdmmc::blocking::{power_on, Error, SdCardError, TimeSource, Timestamp};
 
 pub struct DummyCsPin;
 
@@ -115,10 +115,15 @@ impl From<SdCardError> for MyError {
 
 fn main() -> Result<(), MyError> {
     // BEGIN Fake stuff that will be replaced with real peripherals
-    let spi_bus = RefCell::new(FakeSpiBus());
+    let mut spi_bus = RefCell::new(FakeSpiBus());
     let delay = FakeDelayer();
-    let sdmmc_spi = embedded_hal_bus::spi::RefCellDevice::new(&spi_bus, DummyCsPin, delay).unwrap();
     let time_source = FakeTimesource();
+    // END Fake stuff that will be replaced with real peripherals
+
+    power_on(spi_bus.get_mut(), &mut DummyCsPin)?;
+
+    // BEGIN Fake stuff that will be replaced with real peripherals
+    let sdmmc_spi = embedded_hal_bus::spi::RefCellDevice::new(&spi_bus, DummyCsPin, delay).unwrap();
     // END Fake stuff that will be replaced with real peripherals
 
     use embedded_sdmmc::blocking::{Mode, SdCard, VolumeIdx, VolumeManager};

--- a/src/inner/mod.rs
+++ b/src/inner/mod.rs
@@ -25,6 +25,9 @@ use super::{bisync, only_async, only_sync};
 pub use blockdevice::{Block, BlockCache, BlockCount, BlockDevice, BlockIdx};
 
 #[doc(inline)]
+pub use sdcard::power_on;
+
+#[doc(inline)]
 pub use fat::{FatVolume, VolumeName};
 
 #[doc(inline)]

--- a/src/inner/sdcard/mod.rs
+++ b/src/inner/sdcard/mod.rs
@@ -5,10 +5,11 @@
 
 pub use crate::common::sdcard::proto;
 
-use super::super::{bisync, DelayNs, SpiDevice};
+use super::super::{bisync, DelayNs, SpiBus, SpiDevice};
 
 use super::blockdevice::{Block, BlockCount, BlockDevice, BlockIdx};
 use core::cell::RefCell;
+use embedded_hal::digital::OutputPin;
 use proto::*;
 
 // ****************************************************************************
@@ -23,6 +24,17 @@ use crate::{debug, trace, warn};
 
 /// The max number of bytes in a command response.
 const COMMAND_RESPONSE_BYTES: usize = 5;
+
+/// Power on
+#[bisync]
+pub async fn power_on<BUS, CS>(spi: &mut BUS, cs: &mut CS) -> Result<(), Error>
+where
+    BUS: SpiBus,
+    CS: OutputPin,
+{
+    cs.set_high().map_err(|_| Error::Transport)?;
+    spi.write(&[0xFF; 10]).await.map_err(|_| Error::Transport)
+}
 
 /// Driver for an SD Card on an SPI bus.
 ///

--- a/src/inner/sdcard/mod.rs
+++ b/src/inner/sdcard/mod.rs
@@ -528,7 +528,7 @@ where
         const MAX_WAIT_BYTES: usize = 8;
         const TRANSFER_BYTES: usize = COMMAND_BYTES + MAX_WAIT_BYTES + COMMAND_RESPONSE_BYTES;
 
-        let mut buf: [u8; 19] = [0xFF; TRANSFER_BYTES];
+        let mut buf = [0xFF; TRANSFER_BYTES];
         buf[0] = 0x40 | command;
         buf[1] = (arg >> 24) as u8;
         buf[2] = (arg >> 16) as u8;

--- a/src/inner/sdcard/mod.rs
+++ b/src/inner/sdcard/mod.rs
@@ -502,7 +502,7 @@ where
             Ok(())
         };
         let result = f.await;
-        let _ = self.read_byte();
+        let _ = self.read_byte().await;
         result
     }
 

--- a/src/inner/sdcard/mod.rs
+++ b/src/inner/sdcard/mod.rs
@@ -523,12 +523,12 @@ where
         }
 
         const COMMAND_BYTES: usize = 6;
-        // The maximum number of bytes before the card should start sending the response. Based on
+        // The number of bytes Ncr before the card should start sending the response is between 1 and 8. Based on
         // http://elm-chan.org/docs/mmc/mmc_e.html
         const MAX_WAIT_BYTES: usize = 8;
         const TRANSFER_BYTES: usize = COMMAND_BYTES + MAX_WAIT_BYTES + COMMAND_RESPONSE_BYTES;
 
-        let mut buf = [0xFF; TRANSFER_BYTES];
+        let mut buf: [u8; 19] = [0xFF; TRANSFER_BYTES];
         buf[0] = 0x40 | command;
         buf[1] = (arg >> 24) as u8;
         buf[2] = (arg >> 16) as u8;
@@ -540,10 +540,18 @@ where
         // this allows performing the command without CPU attention and it removes the risk of
         // timeouts on the SD card caused by scheduling delays between sending the command and
         // reading the response.
-        self.transfer_bytes(&mut buf).await?;
+        // CMD17 and CMD18 send the data block after the response. If the response is sent after
+        // less than MAX_WAIT_BYTES, the start block may be already in buf. Therefore, for CMD17 and CMD18,
+        // the response is only searched for in the 2 subsequent COMMAND_BYTES. If none is found,
+        // the system waits for an answer for additional MAX_WAIT_BYTES-2.
+        match command {
+            CMD17 | CMD18 => self.transfer_bytes(&mut buf[0..COMMAND_BYTES + 2]).await?,
+            _ => self.transfer_bytes(&mut buf).await?,
+        };
 
         // Find the response in the buffer
-        buf.iter()
+        let res = buf
+            .iter()
             .skip(COMMAND_BYTES)
             .position(|&b| (b & 0x80) == ERROR_OK)
             .and_then(|pos| {
@@ -551,8 +559,20 @@ where
                 let end = start + COMMAND_RESPONSE_BYTES;
                 buf.get(start..end)
             })
-            .and_then(|bytes| bytes.try_into().ok())
-            .ok_or(Error::UnexpectedResponse(command))
+            .and_then(|bytes| bytes.try_into().ok());
+        match (res, command) {
+            (Some(res), _) => Ok(res),
+            (None, CMD17 | CMD18) => {
+                for _retry in 0..8 - 2 {
+                    let ret = self.read_byte().await?;
+                    if ret & 0x80 == ERROR_OK {
+                        return Ok([ret, 0, 0, 0, 0]);
+                    }
+                }
+                Err(Error::UnexpectedResponse(command))
+            }
+            (None, _) => Err(Error::UnexpectedResponse(command)),
+        }
     }
 
     /// Receive a byte from the SPI bus by clocking out an 0xFF byte.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,20 +89,22 @@ mod structure;
 mod common;
 
 /// Blocking implementation of this crate. Uses traits from embedded_hal & embedded_io crates.
+#[allow(clippy::duplicate_mod)]
 #[path = "."]
 pub mod blocking {
     use bisync::synchronous::*;
-    use embedded_hal::{delay::DelayNs, spi::SpiDevice};
+    use embedded_hal::{delay::DelayNs, spi::SpiBus, spi::SpiDevice};
     use embedded_io::{ErrorType, Read, Seek, SeekFrom, Write};
     mod inner;
     pub use inner::*;
 }
 
 /// Async implementation of this crate. Uses traits from embedded_hal_async & embedded_io_async crates.
+#[allow(clippy::duplicate_mod)]
 #[path = "."]
 pub mod asynchronous {
     use bisync::asynchronous::*;
-    use embedded_hal_async::{delay::DelayNs, spi::SpiDevice};
+    use embedded_hal_async::{delay::DelayNs, spi::SpiBus, spi::SpiDevice};
     use embedded_io_async::{ErrorType, Read, Seek, SeekFrom, Write};
     mod inner;
     pub use inner::*;


### PR DESCRIPTION
Without the fix, I get a `DeviceError(ReadError)` because CMD17 does not detect a start block